### PR TITLE
Minor documentation fix for link_template_to_host.

### DIFF
--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -1773,7 +1773,7 @@ class zabbixcli(cmd.Cmd):
         one/several hosts
 
         COMMAND:
-        add_host_to_hostgroup [templates]
+        link_template_to_host [templates]
                               [hostnames]
 
 


### PR DESCRIPTION
 - link_template_to_host called itself add_host_to_hostgroup in
   the help text for the command.