### PR TITLE
Adding a .spec file to build a rpm for zabbix-cli (tested on el6/el7)

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -84,7 +84,13 @@ lastest version from the master branch at the GitHub repository.
 Installing via RPM packages
 ---------------------------
 
-TODO
+Find the zabbix-cli in your distribution (if distributed already) or build it from the included .spec file (assuming that you have rpm-build, python-setuptools, python-devel pkgs installed) like this : 
+
+::
+  [user@node]$ rpmbuild -ba zabbix-cli.spec --define 'dist .el7' --define 'el7 1'#for el7
+  [user@node]$ rpmbuild -ba zabbix-cli.spec --define 'dist .el6' --define 'el6 1'#for el6
+ 
+Then you can install it (for example through "yum localinstall" zabbix-cli-<version>.rpm 
 
 Installing via Deb packages
 ----------------------------

--- a/zabbix-cli.spec
+++ b/zabbix-cli.spec
@@ -1,0 +1,42 @@
+Name: zabbix-cli		
+Version: 1.5.4	
+Release: 1%{?dist}
+Summary: Command-line interface for Zabbix	
+Group: System Environment/Base	
+License: GPL	
+URL: https://github.com/usit-gd/zabbix-cli	
+Source0: https://github.com/usit-gd/zabbix-cli/archive/%{version}.tar.gz	
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+BuildArch: noarch
+BuildRequires: python-devel 
+BuildRequires: python-setuptools 
+Requires: python-requests	
+%{?el6:Requires: python-argparse}
+
+%description
+Command-line interface for Zabbix monitoring system.
+
+%prep
+%setup -q
+
+%build
+
+
+%install
+./setup.py install --root="%{buildroot}"
+
+
+%files
+%defattr(-, root, root, 0755)
+%config(noreplace) /etc/zabbix-cli/zabbix-cli.conf
+/usr/bin/zabbix-cli
+/usr/bin/zabbix-cli-bulk-execution
+/usr/bin/zabbix-cli-init
+%{python_sitelib}/*
+
+
+
+%changelog
+* Thu Sep 22 2016 - Fabian Arrotin <arrfab@centos.org> - 1.5.4
+- initial spec


### PR DESCRIPTION
- Added initial .spec file to build a rpm for zabbix-cli
- Modified manual to reflect the way to build the RPM pkg