### PR TITLE
Some RPM spec file clean-up

### DIFF
--- a/rpm/zabbix-cli.spec
+++ b/rpm/zabbix-cli.spec
@@ -3,31 +3,31 @@
 %{!?python2_sitelib: %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %{!?python2_sitearch: %global python2_sitearch %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 %endif
-%{!?pybasever: %define pybasever %(%{__python2} -c "import sys;print(sys.version[0:3])")}
+%{!?pybasever: %global pybasever %(%{__python2} -c "import sys;print(sys.version[0:3])")}
 
-Name: zabbix-cli		
-Version: 1.5.4	
-Release: 4%{?dist}
-Summary: Command-line interface for Zabbix	
+Name: zabbix-cli
+Version: 1.5.4
+Release: 5%{?dist}
+Summary: Command-line interface for Zabbix
 
-Group: System Environment/Base	
-License: GPLv3	
-URL: https://github.com/usit-gd/zabbix-cli	
-Source0: https://github.com/usit-gd/zabbix-cli/archive/%{version}.tar.gz	
+Group: System Environment/Base
+License: GPLv3+
+URL: https://github.com/usit-gd/zabbix-cli
+Source0: https://github.com/usit-gd/zabbix-cli/archive/%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
-Requires:	python2, python-setuptools, python-argparse, python-requests
-BuildRequires:	python2-devel, python-setuptools
+Requires: python-argparse, python-requests
+BuildRequires: python2-devel, python-setuptools
 BuildArch:      noarch
 
 %description
 Command-line interface for Zabbix monitoring system.
 
 %prep
-%setup -n zabbix-cli-%{version} -q
+%setup -q
 
-%build		
+%build
 %{__python2} setup.py build
 
 %install
@@ -35,14 +35,26 @@ Command-line interface for Zabbix monitoring system.
 
 %files
 %defattr(-, root, root, 0755)
+%license LICENSE
 %{python2_sitelib}/zabbix_cli-%{version}-py%{pybasever}.egg-info/
 %{python2_sitelib}/zabbix_cli/
 %{_bindir}/zabbix-cli*
+%dir %{_sysconfdir}/zabbix-cli/
 %config(noreplace) %{_sysconfdir}/zabbix-cli/zabbix-cli.conf
 
 %changelog
+* Sat Oct 29 2016 Volker Froehlich <volker27@gmx.at> - 1.5.4-5
+- Match the actual license claimed in the code
+- Remove -n from the setup macro, because it was the default
+- Own the config directory
+- Don't require setuptools
+- Replace define with global
+- Remove python2 from Requires, as it is probably installed anyway
+  and is a dependency of the required modules anyway
+- Add license file
+
 * Fri Oct 14 2016 Rafael Martinez Guerrero <r.m.guerrero@usit.uio.no> - 1.5.4-4
-- Merge internal UiO spec file with Fabians file 
+- Merge internal UiO spec file with Fabians file
 
 * Thu Sep 22 2016 - Fabian Arrotin <arrfab@centos.org> - 1.5.4
 - initial spec


### PR DESCRIPTION
I did some cleanup according to Fedora/EPEL (and RHEL) packaging guidelines here.

If you are really aiming for EL5, like your ifs suggest: It doesn't work -- at least not in mock, which is usually a reliable sign.

```
+ /usr/bin/python2 setup.py build
  File "setup.py", line 38
    with open('zabbix_cli/version.py', 'r') as version_file:
            ^
SyntaxError: invalid syntax
```
