### PR TITLE
Don't trip over UTF8 in config export.

### DIFF
--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -6143,7 +6143,7 @@ class zabbixcli(cmd.Cmd):
                     filename = self.generate_export_filename(directory_exports,obj_type,obj_name_key,object_name_list[obj_name_key])
                     
                     with open(filename,'w') as export_filename:
-                        export_filename.write(output)
+                        export_filename.write(output.encode("utf8"))
 
                     if self.conf.logging == 'ON':
                         self.logs.logger.info('Export file/s for object type [%s] and object name [%s] generated',obj_type,object_name_list[obj_name_key])


### PR DESCRIPTION
Some of my zabbix templates contain utf-8 characters. Trying to export these templates fails:

```
$ zabbix-cli --command "export_configuration tmp templates Varnish"
[...]
2016-12-16 13:34:12,569 [zabbix-cli][flo][15067][ERROR]: Problems generating export file for object type [templates] and object name [Varnish] - 'ascii' codec can't encode character u'\xfc' in position 267: ordinal not in range(128)
```

The PR fixes this issue:

```
2016-12-16 13:59:32,390 [zabbix-cli][flo][10206][INFO]: Export file/s for object type [templates] and object name [Varnish] generated
```
