### PR TITLE
Update cli.py

### DIFF
--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -2784,7 +2784,7 @@ class zabbixcli(cmd.Cmd):
 
         for hostgroup in self.conf.default_hostgroup.split(','):
             
-            if hostgroup_exists(hostgroup.strip()) == False:
+            if self.hostgroup_exists(hostgroup.strip()) == False:
                 hostgroup_default = ''
                 break
         


### PR DESCRIPTION
when call create_host command line, error happened.
Reproduce steps:
zabbix-cli -C "create_host 118.190.67.xx enterprise-cluster-fit2cloud .+ 1"

error prompted: 
[ERROR]: %s
global name 'hostgroup_exists' is not defined

just fix cli.py, to correct "if hostgroup_exists(hostgroup.strip()) == False" to "if **self.**hostgroup_exists(hostgroup.strip()) == False"  is ok