### PR TITLE
fix whitespace removal from group names

### DIFF
--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -2911,8 +2911,8 @@ class zabbixcli(cmd.Cmd):
             # Generate lists with hostID anf hostgroupID information.
             #
 
-            for value in host_hostgroup.replace(' ', '').split(','):
-
+            for value in host_hostgroup.split(','):
+                value = value.strip()
                 if self.host_exists(value):
                     host_ids.append(self.get_host_id(value))
 


### PR DESCRIPTION
as can be seen from example bellow before patch and after
```
[zabbix-cli Admin@zabbix-prod]$ create_maintenance_definition "01TestMW" "" "ABG PROD","ABG TEST CRM" "2 hours" 0

[Error]: Problems creating maintenance definition (01TestMW)


[zabbix-cli Admin@zabbix-prod]$ 
```

and after simple fix

```
[zabbix-cli Admin@zabbix-prod]$ create_maintenance_definition "01TestMW" "" "ABG PROD","ABG TEST CRM" "2 hours" 0

[Done]: Maintenance definition with name [01TestMW] created


[zabbix-cli Admin@zabbix-prod]$ 
```